### PR TITLE
Add delete journal functionality

### DIFF
--- a/e2e/dashboard.auth.spec.ts
+++ b/e2e/dashboard.auth.spec.ts
@@ -49,4 +49,10 @@ test('can create a journal, add an entry, and invite a collaborator', async ({ p
 
   await page.getByRole('button', { name: 'Collaborators (0)' }).click()
   await expect(page.getByText('Not shared with anyone yet.')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Delete' }).click()
+  await page.getByRole('dialog', { name: 'Delete journal' }).getByRole('button', { name: 'Delete' }).click()
+
+  await expect(page).toHaveURL('/dashboard')
+  await expect(page.getByText(journalTitle)).not.toBeVisible()
 })

--- a/src/app/dashboard/actions.test.ts
+++ b/src/app/dashboard/actions.test.ts
@@ -1,19 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { createJournalForOwnerMock, getCurrentAppUserMock } = vi.hoisted(() => ({
+const {
+  createJournalForOwnerMock,
+  deleteJournalOwnedByUserMock,
+  getCurrentAppUserMock,
+} = vi.hoisted(() => ({
   createJournalForOwnerMock: vi.fn(),
+  deleteJournalOwnedByUserMock: vi.fn(),
   getCurrentAppUserMock: vi.fn(),
 }))
 
 vi.mock('@/data/journals', () => ({
   createJournalForOwner: createJournalForOwnerMock,
+  deleteJournalOwnedByUser: deleteJournalOwnedByUserMock,
 }))
 
 vi.mock('@/lib/get-current-app-user', () => ({
   getCurrentAppUser: getCurrentAppUserMock,
 }))
 
-import { createJournalAction } from '@/app/dashboard/actions'
+import { createJournalAction, deleteJournalAction } from '@/app/dashboard/actions'
 
 describe('createJournalAction', () => {
   beforeEach(() => {
@@ -83,6 +89,72 @@ describe('createJournalAction', () => {
       ownerUserId: 'user-1',
       title: 'Trip Notes',
       description: null,
+    })
+  })
+})
+
+describe('deleteJournalAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an auth error when no app user exists', async () => {
+    getCurrentAppUserMock.mockResolvedValue(null)
+
+    const result = await deleteJournalAction({
+      journalId: 'f0cd7f58-022f-44c2-963b-9aaf33dd5f2d',
+    })
+
+    expect(result).toEqual({
+      error: 'You must be signed in to delete a journal.',
+      success: false,
+    })
+    expect(deleteJournalOwnedByUserMock).not.toHaveBeenCalled()
+  })
+
+  it('validates journal id before calling the data helper', async () => {
+    getCurrentAppUserMock.mockResolvedValue({ id: 'user-1' })
+
+    const result = await deleteJournalAction({
+      journalId: 'not-a-uuid',
+    })
+
+    expect(result).toEqual({
+      error: 'Invalid journal id.',
+      success: false,
+    })
+    expect(deleteJournalOwnedByUserMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a permission error when no journal is deleted', async () => {
+    getCurrentAppUserMock.mockResolvedValue({ id: 'user-1' })
+    deleteJournalOwnedByUserMock.mockResolvedValue(false)
+
+    const result = await deleteJournalAction({
+      journalId: 'f0cd7f58-022f-44c2-963b-9aaf33dd5f2d',
+    })
+
+    expect(deleteJournalOwnedByUserMock).toHaveBeenCalledWith({
+      userId: 'user-1',
+      journalId: 'f0cd7f58-022f-44c2-963b-9aaf33dd5f2d',
+    })
+    expect(result).toEqual({
+      error: 'Journal not found or you do not have permission to delete it.',
+      success: false,
+    })
+  })
+
+  it('returns success when owner journal is deleted', async () => {
+    getCurrentAppUserMock.mockResolvedValue({ id: 'user-1' })
+    deleteJournalOwnedByUserMock.mockResolvedValue(true)
+
+    const result = await deleteJournalAction({
+      journalId: 'f0cd7f58-022f-44c2-963b-9aaf33dd5f2d',
+    })
+
+    expect(result).toEqual({
+      error: null,
+      success: true,
     })
   })
 })

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod'
 
-import { createJournalForOwner } from '@/data/journals'
+import { createJournalForOwner, deleteJournalOwnedByUser } from '@/data/journals'
 import { getCurrentAppUser } from '@/lib/get-current-app-user'
 
 export type CreateJournalInput = {
@@ -15,9 +15,22 @@ export type CreateJournalState = {
   redirectTo: string | null
 }
 
+export type DeleteJournalInput = {
+  journalId: string
+}
+
+export type DeleteJournalState = {
+  error: string | null
+  success: boolean
+}
+
 const createJournalSchema = z.object({
   title: z.string().trim().min(1, 'Title is required.').max(180, 'Title must be 180 characters or less.'),
   description: z.string().trim().max(2000, 'Description must be 2000 characters or less.'),
+})
+
+const deleteJournalSchema = z.object({
+  journalId: z.string().uuid('Invalid journal id.'),
 })
 
 export async function createJournalAction(
@@ -50,5 +63,44 @@ export async function createJournalAction(
   return {
     error: null,
     redirectTo: `/dashboard/journals/${createdJournal.id}`,
+  }
+}
+
+export async function deleteJournalAction(
+  input: DeleteJournalInput,
+): Promise<DeleteJournalState> {
+  const currentUser = await getCurrentAppUser()
+
+  if (!currentUser) {
+    return {
+      error: 'You must be signed in to delete a journal.',
+      success: false,
+    }
+  }
+
+  const parsedInput = deleteJournalSchema.safeParse(input)
+
+  if (!parsedInput.success) {
+    return {
+      error: parsedInput.error.issues[0]?.message ?? 'Unable to delete journal.',
+      success: false,
+    }
+  }
+
+  const deleted = await deleteJournalOwnedByUser({
+    userId: currentUser.id,
+    journalId: parsedInput.data.journalId,
+  })
+
+  if (!deleted) {
+    return {
+      error: 'Journal not found or you do not have permission to delete it.',
+      success: false,
+    }
+  }
+
+  return {
+    error: null,
+    success: true,
   }
 }

--- a/src/app/dashboard/delete-journal-button.tsx
+++ b/src/app/dashboard/delete-journal-button.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
+
+import {
+  type DeleteJournalInput,
+  type DeleteJournalState,
+} from '@/app/dashboard/actions'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+
+type DeleteJournalButtonProps = {
+  journalId: string
+  action: (input: DeleteJournalInput) => Promise<DeleteJournalState>
+  successRedirectTo?: string
+}
+
+export function DeleteJournalButton({ journalId, action, successRedirectTo }: DeleteJournalButtonProps) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [state, setState] = useState<DeleteJournalState>({
+    error: null,
+    success: false,
+  })
+  const [pending, startTransition] = useTransition()
+
+  function handleDelete() {
+    startTransition(async () => {
+      const nextState = await action({ journalId })
+      setState(nextState)
+
+      if (nextState.success) {
+        setOpen(false)
+
+        if (successRedirectTo) {
+          router.push(successRedirectTo)
+          return
+        }
+
+        router.refresh()
+      }
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" size="sm" variant="outline" className="text-destructive hover:text-destructive">
+          Delete
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete journal</DialogTitle>
+          <DialogDescription>
+            This will permanently remove this journal and all of its entries. This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        {state.error ? <p className="text-destructive text-sm">{state.error}</p> : null}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleDelete} disabled={pending}>
+            {pending ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/dashboard/journals/[journalId]/page.test.tsx
+++ b/src/app/dashboard/journals/[journalId]/page.test.tsx
@@ -40,6 +40,10 @@ vi.mock('@/app/dashboard/journals/[journalId]/invite-user-modal', () => ({
   InviteUserModal: () => <div data-testid="invite-user-modal">Invite user modal</div>,
 }))
 
+vi.mock('@/app/dashboard/delete-journal-button', () => ({
+  DeleteJournalButton: () => <div data-testid="delete-journal-button">Delete journal</div>,
+}))
+
 vi.mock('@/app/dashboard/journals/[journalId]/actions', () => ({
   createEntryAction: vi.fn(),
   createInviteAction: vi.fn(),
@@ -88,6 +92,7 @@ describe('JournalDetailsPage', () => {
       id: 'journal-1',
       title: 'Family Journal',
       description: 'Shared notes and reflections',
+      isOwner: true,
     })
     getCollaboratorsForJournalMock.mockResolvedValue([
       {
@@ -154,6 +159,7 @@ describe('JournalDetailsPage', () => {
 
     expect(screen.getByTestId('create-entry-modal')).toBeInTheDocument()
     expect(screen.getByTestId('invite-user-modal')).toBeInTheDocument()
+    expect(screen.getByTestId('delete-journal-button')).toBeInTheDocument()
   })
 
   it('renders empty entries state when there are no journal entries', async () => {
@@ -166,5 +172,18 @@ describe('JournalDetailsPage', () => {
     expect(screen.getByText('No entries yet')).toBeInTheDocument()
     expect(screen.getByText('This journal does not have any entries yet.')).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Pending invites' })).not.toBeInTheDocument()
+  })
+
+  it('does not render delete button for journals shared with the user', async () => {
+    getUserJournalByIdMock.mockResolvedValue({
+      id: 'journal-1',
+      title: 'Family Journal',
+      description: 'Shared notes and reflections',
+      isOwner: false,
+    })
+
+    await renderJournalDetailsPage()
+
+    expect(screen.queryByTestId('delete-journal-button')).not.toBeInTheDocument()
   })
 })

--- a/src/app/dashboard/journals/[journalId]/page.tsx
+++ b/src/app/dashboard/journals/[journalId]/page.tsx
@@ -19,6 +19,8 @@ import {
   createEntryAction,
   createInviteAction,
 } from '@/app/dashboard/journals/[journalId]/actions'
+import { deleteJournalAction } from '@/app/dashboard/actions'
+import { DeleteJournalButton } from '@/app/dashboard/delete-journal-button'
 import { CreateEntryModal } from '@/app/dashboard/journals/[journalId]/create-entry-modal'
 import { InviteUserModal } from '@/app/dashboard/journals/[journalId]/invite-user-modal'
 import {
@@ -106,6 +108,13 @@ export default async function JournalDetailsPage({ params }: JournalDetailsPageP
             </div>
           </div>
           <div className="flex items-center gap-2">
+            {journal.isOwner ? (
+              <DeleteJournalButton
+                journalId={journalId}
+                action={deleteJournalAction}
+                successRedirectTo="/dashboard"
+              />
+            ) : null}
             <CreateEntryModal journalId={journalId} action={createEntryAction} />
             <InviteUserModal journalId={journalId} journalTitle={journalTitle} action={createInviteAction} />
           </div>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -22,6 +22,12 @@ vi.mock('@/app/dashboard/create-journal-modal', () => ({
   ),
 }))
 
+vi.mock('@/app/dashboard/delete-journal-button', () => ({
+  DeleteJournalButton: ({ journalId }: { journalId: string }) => (
+    <div data-testid={`delete-journal-${journalId}`}>Delete</div>
+  ),
+}))
+
 vi.mock('@/lib/get-current-app-user', () => ({
   getCurrentAppUser: getCurrentAppUserMock,
 }))
@@ -94,6 +100,7 @@ describe('DashboardPage', () => {
         id: 'journal-1',
         title: 'Family Journal',
         description: 'Daily family reflections',
+        isOwner: true,
       },
     ])
 
@@ -105,6 +112,32 @@ describe('DashboardPage', () => {
 
     expect(screen.getByText('Family Journal')).toBeInTheDocument()
     expect(screen.getByText('Daily family reflections')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open Family Journal' })).toBeInTheDocument()
+    expect(screen.getByTestId('delete-journal-journal-1')).toBeInTheDocument()
+  })
+
+  it('renders delete button only for journals owned by current user', async () => {
+    getUserJournalsMock.mockResolvedValue([
+      {
+        id: 'journal-1',
+        title: 'Owned Journal',
+        description: null,
+        isOwner: true,
+      },
+      {
+        id: 'journal-2',
+        title: 'Shared With Me',
+        description: null,
+        isOwner: false,
+      },
+    ])
+
+    await renderDashboardPage()
+
+    expect(screen.getByRole('link', { name: 'Open Owned Journal' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Open Shared With Me' })).toBeInTheDocument()
+    expect(screen.getByTestId('delete-journal-journal-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('delete-journal-journal-2')).not.toBeInTheDocument()
   })
 
   it('does not fetch pending invitations when current user email is unavailable', async () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,13 +2,15 @@ import { format } from 'date-fns'
 import Link from 'next/link'
 
 import {
+  CardContent,
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { createJournalAction } from '@/app/dashboard/actions'
+import { createJournalAction, deleteJournalAction } from '@/app/dashboard/actions'
 import { CreateJournalModal } from '@/app/dashboard/create-journal-modal'
+import { DeleteJournalButton } from '@/app/dashboard/delete-journal-button'
 import { getPendingInvitationsForEmail } from '@/data/invitations'
 import { getUserJournals, type UserJournal } from '@/data/journals'
 import { getCurrentAppUser } from '@/lib/get-current-app-user'
@@ -74,14 +76,24 @@ export default async function DashboardPage() {
         </Card>
       ) : (
         userJournals.map((journal: UserJournal) => (
-          <Link key={journal.id} href={`/dashboard/journals/${journal.id}`} className="block">
-            <Card className="transition-colors hover:bg-muted/40">
-              <CardHeader>
-                <CardTitle>{journal.title}</CardTitle>
-                <CardDescription>{journal.description || 'No description'}</CardDescription>
-              </CardHeader>
-            </Card>
-          </Link>
+          <Card key={journal.id} className="relative gap-3 transition-colors hover:bg-muted/40">
+            <Link
+              href={`/dashboard/journals/${journal.id}`}
+              aria-label={`Open ${journal.title}`}
+              className="focus-visible:ring-ring absolute inset-0 rounded-xl focus-visible:ring-2"
+            />
+            <CardHeader className="relative z-10 pointer-events-none">
+              <CardTitle>{journal.title}</CardTitle>
+              <CardDescription>{journal.description || 'No description'}</CardDescription>
+            </CardHeader>
+            {journal.isOwner ? (
+              <CardContent className="relative z-20 pt-0 pointer-events-none">
+                <div className="ml-auto w-fit pointer-events-auto">
+                  <DeleteJournalButton journalId={journal.id} action={deleteJournalAction} />
+                </div>
+              </CardContent>
+            ) : null}
+          </Card>
         ))
       )}
     </main>

--- a/src/data/journals.integration.test.ts
+++ b/src/data/journals.integration.test.ts
@@ -5,6 +5,7 @@ import { db } from '@/db'
 import { journalMembers, journals, users } from '@/db/schema'
 import {
   createJournalForOwner,
+  deleteJournalOwnedByUser,
   getCollaboratorsForJournal,
   getUserJournalById,
   getUserJournals,
@@ -105,6 +106,7 @@ describe('getUserJournals', () => {
     const ids = result.map((j) => j.id)
     expect(ids).toContain(journalId1)
     expect(ids).toContain(journalId2)
+    expect(result.every((journal) => journal.isOwner)).toBe(true)
   })
 
   it('returns only journals the member belongs to', async () => {
@@ -113,6 +115,7 @@ describe('getUserJournals', () => {
     const ids = result.map((j) => j.id)
     expect(ids).toContain(journalId1)
     expect(ids).not.toContain(journalId2)
+    expect(result.every((journal) => !journal.isOwner)).toBe(true)
   })
 
   it('returns empty array for a user with no memberships', async () => {
@@ -132,6 +135,63 @@ describe('getUserJournals', () => {
     expect(found?.description).toBe('A description.')
 
     await deleteJournals([journalWithDesc.id])
+  })
+})
+
+describe('deleteJournalOwnedByUser', () => {
+  let ownerId: string
+  let memberId: string
+  let journalId: string
+
+  beforeEach(async () => {
+    const owner = await createUser({ displayName: 'Owner' })
+    const member = await createUser({ displayName: 'Member' })
+
+    ownerId = owner.id
+    memberId = member.id
+
+    const journal = await createJournal(ownerId, 'Delete Journal')
+    journalId = journal.id
+
+    await addMember(journalId, ownerId, 'owner')
+    await addMember(journalId, memberId, 'editor')
+  })
+
+  afterEach(async () => {
+    await deleteJournals([journalId])
+    await deleteUsers([ownerId, memberId])
+  })
+
+  it('deletes a journal when requested by its owner', async () => {
+    const deleted = await deleteJournalOwnedByUser({
+      userId: ownerId,
+      journalId,
+    })
+
+    expect(deleted).toBe(true)
+
+    const [journal] = await db
+      .select({ id: journals.id })
+      .from(journals)
+      .where(eq(journals.id, journalId))
+
+    expect(journal).toBeUndefined()
+  })
+
+  it('does not delete a journal when requested by a non-owner member', async () => {
+    const deleted = await deleteJournalOwnedByUser({
+      userId: memberId,
+      journalId,
+    })
+
+    expect(deleted).toBe(false)
+
+    const [journal] = await db
+      .select({ id: journals.id })
+      .from(journals)
+      .where(eq(journals.id, journalId))
+
+    expect(journal?.id).toBe(journalId)
   })
 })
 
@@ -165,6 +225,7 @@ describe('getUserJournalById', () => {
     expect(result?.id).toBe(journalId)
     expect(result?.title).toBe('Detail Journal')
     expect(result?.description).toBe('Some details.')
+    expect(result?.isOwner).toBe(true)
   })
 
   it('returns null for a user who is not a member', async () => {
@@ -186,6 +247,7 @@ describe('getUserJournalById', () => {
     const result = await getUserJournalById(editor.id, journalId)
 
     expect(result?.id).toBe(journalId)
+    expect(result?.isOwner).toBe(false)
 
     await deleteUsers([editor.id])
   })

--- a/src/data/journals.ts
+++ b/src/data/journals.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ne } from 'drizzle-orm'
+import { and, desc, eq, ne, sql } from 'drizzle-orm'
 
 import { db } from '@/db'
 import { journalMembers, journals, users } from '@/db/schema'
@@ -7,6 +7,7 @@ export type UserJournal = {
   id: string
   title: string
   description: string | null
+  isOwner: boolean
 }
 
 /**
@@ -18,6 +19,7 @@ export async function getUserJournals(userId: string): Promise<UserJournal[]> {
       id: journals.id,
       title: journals.title,
       description: journals.description,
+      isOwner: sql<boolean>`${journals.ownerUserId} = ${userId}`,
     })
     .from(journals)
     .innerJoin(journalMembers, eq(journalMembers.journalId, journals.id))
@@ -26,10 +28,26 @@ export async function getUserJournals(userId: string): Promise<UserJournal[]> {
     .orderBy(desc(journals.updatedAt))
 }
 
+/**
+ * Delete a journal only if the requesting user is the owner.
+ */
+export async function deleteJournalOwnedByUser(input: {
+  userId: string
+  journalId: string
+}): Promise<boolean> {
+  const deleted = await db
+    .delete(journals)
+    .where(and(eq(journals.id, input.journalId), eq(journals.ownerUserId, input.userId)))
+    .returning({ id: journals.id })
+
+  return deleted.length > 0
+}
+
 export type UserJournalDetails = {
   id: string
   title: string
   description: string | null
+  isOwner: boolean
 }
 
 export type JournalCollaborator = {
@@ -50,6 +68,7 @@ export async function getUserJournalById(
       id: journals.id,
       title: journals.title,
       description: journals.description,
+      isOwner: sql<boolean>`${journals.ownerUserId} = ${userId}`,
     })
     .from(journals)
     .innerJoin(journalMembers, eq(journalMembers.journalId, journals.id))


### PR DESCRIPTION
This pull request adds the ability for users to delete journals they own from the dashboard, including all necessary backend, UI, and test changes. Only journal owners can see and use the delete option, and appropriate checks and error handling are implemented throughout the stack. The PR also ensures that the UI and integration tests cover ownership and deletion scenarios.

**Major features and changes:**

**Backend & API:**
- Added `deleteJournalOwnedByUser` data helper and `deleteJournalAction` server action, including input validation and ownership checks to ensure only the journal owner can delete a journal. [[1]](diffhunk://#diff-46c41e70d07670106108691efaad56ca47d3ba6953e780b1b6a0cfda3152db1bL5-R5) [[2]](diffhunk://#diff-46c41e70d07670106108691efaad56ca47d3ba6953e780b1b6a0cfda3152db1bR18-R35) [[3]](diffhunk://#diff-46c41e70d07670106108691efaad56ca47d3ba6953e780b1b6a0cfda3152db1bR68-R106) [[4]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R8) [[5]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R141-R197)
- Updated types and schemas to support deletion actions and states.

**UI Components:**
- Introduced the `DeleteJournalButton` component, which opens a confirmation dialog and calls the delete action. It is only rendered for journals owned by the current user. [[1]](diffhunk://#diff-8a6a8b3d0dae33f6d6156fef8ceaa6c1fef3018a2236a21de559ec1810c47329R1-R80) [src/app/dashboard/journals/[journalId]/page.tsxR22-R23](diffhunk://#diff-b191716bdc1261b2a905361ff18b25b4aaefc696090611fe11e621a2a5dcb8f9R22-R23), [src/app/dashboard/journals/[journalId]/page.tsxR111-R117](diffhunk://#diff-b191716bdc1261b2a905361ff18b25b4aaefc696090611fe11e621a2a5dcb8f9R111-R117), [[2]](diffhunk://#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888fR5-R13) [[3]](diffhunk://#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888fL77-L84)
- Updated dashboard and journal details pages to conditionally show the delete button for owner journals. ([src/app/dashboard/page.tsxL77-L84](diffhunk://#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888fL77-L84), [src/app/dashboard/journals/[journalId]/page.tsxR111-R117](diffhunk://#diff-b191716bdc1261b2a905361ff18b25b4aaefc696090611fe11e621a2a5dcb8f9R111-R117))

**Testing:**
- Added and expanded unit, integration, and end-to-end tests to verify journal deletion, ownership logic, and UI visibility. This includes tests for successful deletion, permission errors, and correct rendering of the delete button. [[1]](diffhunk://#diff-f1b39fe2ec37bd086a70c6a719025d4a01710799ddedd2b89c7dc51073d2ab91L3-R22) [[2]](diffhunk://#diff-f1b39fe2ec37bd086a70c6a719025d4a01710799ddedd2b89c7dc51073d2ab91R95-R160) [[3]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R109) [[4]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R118) [[5]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R228) [[6]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R250) [src/app/dashboard/journals/[journalId]/page.test.tsxR43-R46](diffhunk://#diff-4667367d908a4ab90f98ce4275f16a3f4575ba5ea2d510f959046fae553ea045R43-R46), [src/app/dashboard/journals/[journalId]/page.test.tsxR95](diffhunk://#diff-4667367d908a4ab90f98ce4275f16a3f4575ba5ea2d510f959046fae553ea045R95), [src/app/dashboard/journals/[journalId]/page.test.tsxR162](diffhunk://#diff-4667367d908a4ab90f98ce4275f16a3f4575ba5ea2d510f959046fae553ea045R162), [src/app/dashboard/journals/[journalId]/page.test.tsxR176-R188](diffhunk://#diff-4667367d908a4ab90f98ce4275f16a3f4575ba5ea2d510f959046fae553ea045R176-R188), [[7]](diffhunk://#diff-c045fa540d4115f19edf411c2e0404fa57f725d7b55100d71ff91fc54ef194a4R25-R30) [[8]](diffhunk://#diff-c045fa540d4115f19edf411c2e0404fa57f725d7b55100d71ff91fc54ef194a4R103) [[9]](diffhunk://#diff-c045fa540d4115f19edf411c2e0404fa57f725d7b55100d71ff91fc54ef194a4R115-R140) [[10]](diffhunk://#diff-483cb85dc45d0c52f56a526f077fbbbb5318ff0dafc61b2e4a3d3dedd1799d8aR52-R57)

**Ownership Logic:**
- Journal ownership is now explicitly tracked and surfaced in the API and UI, ensuring only owners see and can use the delete functionality. [[1]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R109) [[2]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R118) [[3]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R228) [[4]](diffhunk://#diff-4e93661331ecdeb2e82626e146f55f50284bf5e27e9c69817eb07c4956b68ea5R250) [[5]](diffhunk://#diff-c045fa540d4115f19edf411c2e0404fa57f725d7b55100d71ff91fc54ef194a4R103) [src/app/dashboard/journals/[journalId]/page.test.tsxR95](diffhunk://#diff-4667367d908a4ab90f98ce4275f16a3f4575ba5ea2d510f959046fae553ea045R95))

**End-to-end experience:**
- The end-to-end test now covers deleting a journal and verifies that it is removed from the dashboard.